### PR TITLE
Feature/board specific lcd init

### DIFF
--- a/firmware/eeprom.c
+++ b/firmware/eeprom.c
@@ -1,7 +1,7 @@
 /*
  * 4chord MIDI - EEPROM data
  *
- * Copyright (C) 2018 Sven Gregori <sven@craplab.fi>
+ * Copyright (C) 2020 Sven Gregori <sven@craplab.fi>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -21,11 +21,19 @@
 #include "eeprom.h"
 #include "menu.h"
 #include "uart.h"
+#include "lcd.h"
 
 struct eeprom_data_t eeprom_data EEMEM = {
     /* initial default values */
     .header = {
         .magic = "\xc1\xab\x4c\x0d",
+    },
+    .board_data = {
+        .lcd = {
+            .tcoeff = LCD_DEFAULT_TCOEFF,
+            .bias   = LCD_DEFAULT_BIAS,
+            .vop    = LCD_DEFAULT_VOP,
+        },
     },
     .defaults = {
         .menu  = MENU_KEY,
@@ -91,6 +99,10 @@ restore_defaults(void)
     eeprom_update_byte(&eeprom_data.header.magic[1], 0xab);
     eeprom_update_byte(&eeprom_data.header.magic[2], 0x4c);
     eeprom_update_byte(&eeprom_data.header.magic[3], 0x0d);
+
+    eeprom_update_byte(&eeprom_data.board_data.lcd.tcoeff, LCD_DEFAULT_TCOEFF);
+    eeprom_update_byte(&eeprom_data.board_data.lcd.bias, LCD_DEFAULT_BIAS);
+    eeprom_update_byte(&eeprom_data.board_data.lcd.vop, LCD_DEFAULT_VOP);
 
     eeprom_update_byte(&eeprom_data.defaults.menu, MENU_KEY);
     eeprom_update_byte(&eeprom_data.defaults.key, PLAYBACK_KEY_C);

--- a/firmware/eeprom.h
+++ b/firmware/eeprom.h
@@ -30,7 +30,12 @@ extern struct eeprom_data_t {
          * should be 0xc1ab4c0d -> clab4cod -> CrapLab 4chord MIDI
          */
         uint8_t magic[4];                   /* 0x00 */
-        uint8_t __header_reserved[12];      /* 0x04 */
+        /*
+         * Keeping track of EEPROM data structure version.
+         * See check_update() function in eeprom.c for more information.
+         */
+        uint8_t eeprom_version;             /* 0x04 */
+        uint8_t __header_reserved[11];      /* 0x05 */
     } header;
 
     /* reserved for later use (16 bytes) */

--- a/firmware/eeprom.h
+++ b/firmware/eeprom.h
@@ -1,7 +1,7 @@
 /*
  * 4chord MIDI - EEPROM data
  *
- * Copyright (C) 2018 Sven Gregori <sven@craplab.fi>
+ * Copyright (C) 2020 Sven Gregori <sven@craplab.fi>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -36,8 +36,18 @@ extern struct eeprom_data_t {
     /* reserved for later use (16 bytes) */
     uint8_t __meta[16];                     /* 0x10 */
 
-    /* reserved for later use (16 bytes) */
-    uint8_t __board_data[16];               /* 0x20 */
+    /* board-specific data that may vary between hardware (16 bytes) */
+    struct {
+        struct {
+            /* LCD temperature coefficient (PCD8544 datasheet section 8.7) */
+            uint8_t tcoeff;                 /* 0x20 */
+            /* LCD bias system value (PCD8544 datasheet section 8.8) */
+            uint8_t bias;                   /* 0x21 */
+            /* LCD V_op value (PCD8544 datasheet section 8.9) */
+            uint8_t vop;                    /* 0x22 */
+        } lcd;
+        uint8_t __board_data_reserved[13];  /* 0x23 */
+    } board_data;
 
     /* default settings (16 bytes) */
     struct {

--- a/firmware/lcd.c
+++ b/firmware/lcd.c
@@ -58,6 +58,7 @@
 #include "menu.h"
 #include "spi.h"
 #include "xbmlib.h"
+#include "eeprom.h"
 
 #define LCD_START_LINE_ADDR (66-2)
 #define LCD_X_RES   84
@@ -128,10 +129,9 @@ lcd_init(void)
 {
     /* taken from Olimex Arduino example */
     spi_send_command(0x21);
-    spi_send_command(0xc8);
-    spi_send_command(0x04 | !!(LCD_START_LINE_ADDR & (1u << 6)));
-    spi_send_command(0x40 | (LCD_START_LINE_ADDR & ((1u << 6) -1)));
-    spi_send_command(0x12);
+    spi_send_command(eeprom_read_byte(&eeprom_data.board_data.lcd.vop));
+    spi_send_command(eeprom_read_byte(&eeprom_data.board_data.lcd.tcoeff));
+    spi_send_command(eeprom_read_byte(&eeprom_data.board_data.lcd.bias));
     spi_send_command(0x20);
     spi_send_command(0x08);
     spi_send_command(0x0c);

--- a/firmware/lcd.h
+++ b/firmware/lcd.h
@@ -1,7 +1,7 @@
 /*
  * 4chord MIDI - Nokia LCD handling
  *
- * Copyright (C) 2018 Sven Gregori <sven@craplab.fi>
+ * Copyright (C) 2020 Sven Gregori <sven@craplab.fi>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -27,6 +27,27 @@
 #define lcd_rst_high()  do { LCD_RESET_PORT |=  (1 << LCD_RESET_PIN); } while (0)
 /* set LCD reset pin low */
 #define lcd_rst_low()   do { LCD_RESET_PORT &= ~(1 << LCD_RESET_PIN); } while (0)
+
+
+/**
+ * LCD default temperature coefficient value packed together as
+ * "Temparature control" instruction to send as-is via SPI.
+ * See PCD8544 datasheet section 8.7 for details.
+ */
+#define LCD_DEFAULT_TCOEFF 0x04
+/* LCD bias system value (PCD8544 datasheet section 8.8) */
+/**
+ * LCD default bias system value packed together as
+ * "Bias system" instruction to send as-is via SPI.
+ * See PCD8544 datasheet section 8.8 for details.
+ */
+#define LCD_DEFAULT_BIAS   0x12
+/**
+ * LCD default V_op value packed together as
+ * "Set Vop" instruction to send as-is via SPI.
+ * See PCD8544 datasheet section 8.9 for details.
+ */
+#define LCD_DEFAULT_VOP    0xc8
 
 /**
  * Initialize the LCD.

--- a/firmware/timer.c
+++ b/firmware/timer.c
@@ -1,7 +1,7 @@
 /*
  * 4chord MIDI - Timer handling
  *
- * Copyright (C) 2017 Sven Gregori <sven@craplab.fi>
+ * Copyright (C) 2020 Sven Gregori <sven@craplab.fi>
  *
  * This program is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -34,8 +34,8 @@ timer0_init_pwm(void)
 {
     /* Fast PWM mode 3, PD5 = 1 on BOTTOM, 0 on OCR0B match */
     TCCR0A = (1 << COM0B1) | (1 << WGM01) | (1 << WGM00);
-    /* prescaler 256 */
-    TCCR0B = (1 << CS02);
+    /* prescaler 64 */
+    TCCR0B = (1 << CS01) | (1 << CS00);
     /* Zero output compare, i.e. lights off */
     OCR0B  = 0;
 }


### PR DESCRIPTION
Move some LCD init values to EEPROM so they can be set specifically for the display in use (turns out they could differ a bit and require different operation voltages to have the image nice and clear)